### PR TITLE
Fix regexp in get_devices()

### DIFF
--- a/bt_studio.py
+++ b/bt_studio.py
@@ -352,7 +352,7 @@ def get_devices():
     
     devices_by_adr = {}
     
-    r = re.compile("\/org\/bluez\/hci\d*\/dev\_(.*)")
+    r = re.compile("\/org\/bluez\/hci\d*\/dev\_([^/]*)$")
     # e.g., match a string like this:
     # /org/bluez/hci0/dev_58_C9_35_2F_A1_EF
     


### PR DESCRIPTION
The code incorrectly matches "subpaths" like `/org/bluez/hci0/dev_12_34_56_67_89_ab/fd232` which have no `org.bluez.Device1` object in them.  Ignore these, so that only the top level device object is added to `devices_by_adr`.

(I could have also just checked for the presence of the `org.bluez.Device1` key, but even so, I don't particularly want the subpaths overwriting entries in `devices_by_adr`.)